### PR TITLE
Improve role verification

### DIFF
--- a/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/AbstractKeycloakAuthenticator.java
+++ b/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/AbstractKeycloakAuthenticator.java
@@ -15,15 +15,21 @@ import java.security.Principal;
  */
 public abstract class AbstractKeycloakAuthenticator<P extends Principal> implements Authenticator<HttpServletRequest, P> {
 
+    private final KeycloakConfiguration keycloakConfiguration;
+
+    public AbstractKeycloakAuthenticator(final KeycloakConfiguration keycloakConfiguration) {
+        this.keycloakConfiguration = keycloakConfiguration;
+    }
+
     @Override
     public Optional<P> authenticate(HttpServletRequest request) throws AuthenticationException {
         KeycloakSecurityContext securityContext = (KeycloakSecurityContext) request.getAttribute(KeycloakSecurityContext.class.getName());
         if (securityContext != null) {
-            return Optional.fromNullable(prepareAuthentication(securityContext, request));
+            return Optional.fromNullable(prepareAuthentication(securityContext, request, keycloakConfiguration));
         } else {
             return Optional.absent();
         }
     }
 
-    protected abstract P prepareAuthentication(KeycloakSecurityContext securityContext, HttpServletRequest request);
+    protected abstract P prepareAuthentication(KeycloakSecurityContext securityContext, HttpServletRequest request, KeycloakConfiguration keycloakConfiguration);
 }

--- a/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/KeycloakAuthenticator.java
+++ b/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/KeycloakAuthenticator.java
@@ -11,8 +11,12 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class KeycloakAuthenticator extends AbstractKeycloakAuthenticator<User> {
 
+    public KeycloakAuthenticator(KeycloakConfiguration configuration) {
+        super(configuration);
+    }
+
     @Override
-    protected User prepareAuthentication(KeycloakSecurityContext securityContext, HttpServletRequest request) {
-        return new User(securityContext, request);
+    protected User prepareAuthentication(KeycloakSecurityContext securityContext, HttpServletRequest request, KeycloakConfiguration configuration) {
+        return new User(securityContext, request, configuration);
     }
 }

--- a/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/KeycloakBundle.java
+++ b/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/KeycloakBundle.java
@@ -66,7 +66,7 @@ public abstract class KeycloakBundle<T> implements ConfiguredBundle<T> {
     protected ContainerRequestFilter createAuthFactory(T configuration) {
         return new KeycloakAuthFilter.Builder<Principal>()
                 .setConfig(getKeycloakConfiguration(configuration))
-                .setAuthenticator(createAuthenticator())
+                .setAuthenticator(createAuthenticator(getKeycloakConfiguration(configuration)))
                 .setAuthorizer(createAuthorizer())
                 .setRealm(getRealm(configuration))
                 .buildAuthFilter();
@@ -100,18 +100,18 @@ public abstract class KeycloakBundle<T> implements ConfiguredBundle<T> {
      *
      * @return the authenticator.
      */
-    protected Authenticator createAuthenticator() {
-        return new KeycloakAuthenticator();
+    protected Authenticator createAuthenticator(KeycloakConfiguration configuration) {
+        return new KeycloakAuthenticator(configuration);
     }
 
     /**
      * Prepare the realm name. Override as needed to provide a different name.
      *
-     * @param configuration for future use
+     * @param configuration the application's configuration
      * @return realm name
      */
     protected String getRealm(T configuration) {
-        return "dropwizard";
+        return getKeycloakConfiguration(configuration).getRealm();
     }
 
     protected abstract KeycloakConfiguration getKeycloakConfiguration(T configuration);

--- a/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/KeycloakResource.java
+++ b/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/KeycloakResource.java
@@ -1,0 +1,23 @@
+package de.ahus1.keycloak.dropwizard;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Map the resource name
+ */
+class KeycloakResource {
+
+	private final String resource;
+
+	public KeycloakResource(String resource) {
+		if (StringUtils.isBlank(resource)) {
+			throw new IllegalArgumentException("Cannot build a " + getClass().getName() + " without a resource.");
+		}
+
+		this.resource = resource;
+	}
+
+	public String getResource() {
+		return resource;
+	}
+}

--- a/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/User.java
+++ b/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/User.java
@@ -11,12 +11,12 @@ import javax.ws.rs.ForbiddenException;
  */
 public class User extends AbstractUser {
 
-    public User(KeycloakSecurityContext securityContext, HttpServletRequest request) {
-        super(request, securityContext);
+    public User(KeycloakSecurityContext securityContext, HttpServletRequest request, KeycloakConfiguration keycloakConfiguration) {
+        super(request, securityContext, keycloakConfiguration);
     }
 
     public void checkUserInRole(String role) {
-        if (!securityContext.getToken().getRealmAccess().isUserInRole(role)) {
+        if (!getRoles().contains(role)) {
             throw new ForbiddenException();
         }
     }


### PR DESCRIPTION
By default the resource roles was ignored, which was pretty annoying out of the box.
This feature is now supported.

Also removed the harcoded "dropwizard" realm name, and make use of the configuration value.