### PR TITLE
Support Keycloak 2.5.1.Final and above using 2.1.0.Final API

### DIFF
--- a/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/JaxrsHttpFacade.java
+++ b/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/JaxrsHttpFacade.java
@@ -44,6 +44,12 @@ public class JaxrsHttpFacade implements HttpFacade {
             return requestContext.getUriInfo().getRequestUri().toString();
         }
 
+        //TODO: enable once the adapter is built against Keycloak 2.5.1 and above (see KEYCLOAK-3261)
+        //@Override
+        public String getRelativePath() {
+            return requestContext.getUriInfo().getPath();
+        }
+
         @Override
         public boolean isSecure() {
             return securityContext.isSecure();


### PR DESCRIPTION
This pull adds support for Keycloak 2.5.1 and above on runtime, fixing #9 