### PR TITLE
Changed getRemoteAddr() in JaxrsHttpFacade.java to read host from incoming request object

### DIFF
--- a/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/JaxrsHttpFacade.java
+++ b/keycloak-dropwizard-jaxrs/src/main/java/de/ahus1/keycloak/dropwizard/JaxrsHttpFacade.java
@@ -43,9 +43,8 @@ public class JaxrsHttpFacade implements HttpFacade {
         public String getURI() {
             return requestContext.getUriInfo().getRequestUri().toString();
         }
-
-        //TODO: enable once the adapter is built against Keycloak 2.5.1 and above (see KEYCLOAK-3261)
-        //@Override
+        
+        @Override
         public String getRelativePath() {
             return requestContext.getUriInfo().getPath();
         }
@@ -97,8 +96,8 @@ public class JaxrsHttpFacade implements HttpFacade {
 
         @Override
         public String getRemoteAddr() {
-            // TODO: implement properly
-            return HostUtils.getIpAddress();
+            // Read the URI from the incoming requestConext, instead of from the host itself.
+            return requestContext.getUriInfo().getBaseUri().getHost();
         }
 
         @Override


### PR DESCRIPTION
Small change to the JaxrsHttpFacade to read the host information from the incoming request, instead of trying to look it up via dns hostname. The old way caused issues if the developer's own hostname was not defined in the /etc/hosts file.